### PR TITLE
chore: Update module path to nobl9/go-yaml

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -3,7 +3,7 @@ package ast
 import (
 	"testing"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 )
 
 func TestEscapeSingleQuote(t *testing.T) {

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -3,7 +3,7 @@ package benchmarks
 import (
 	"testing"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	goyaml2 "gopkg.in/yaml.v2"
 	goyaml3 "gopkg.in/yaml.v3"
 )
@@ -41,7 +41,7 @@ elements:
 			}
 		}
 	})
-	b.Run("github.com/goccy/go-yaml", func(b *testing.B) {
+	b.Run("github.com/nobl9/go-yaml", func(b *testing.B) {
 		var t T
 		for i := 0; i < b.N; i++ {
 			if err := yaml.Unmarshal([]byte(src), &t); err != nil {

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -2,10 +2,10 @@ module benchmarks
 
 go 1.12
 
-replace github.com/goccy/go-yaml => ../
+replace github.com/nobl9/go-yaml => ../
 
 require (
-	github.com/goccy/go-yaml v0.0.0-00010101000000-000000000000
+	github.com/nobl9/go-yaml v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
 )

--- a/cmd/ycat/ycat.go
+++ b/cmd/ycat/ycat.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/lexer"
-	"github.com/goccy/go-yaml/printer"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/lexer"
+	"github.com/nobl9/go-yaml/printer"
 	"github.com/mattn/go-colorable"
 )
 

--- a/decode.go
+++ b/decode.go
@@ -17,10 +17,10 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/parser"
+	"github.com/nobl9/go-yaml/token"
 )
 
 // Decoder reads and decodes YAML values from an input stream.

--- a/decode_test.go
+++ b/decode_test.go
@@ -16,10 +16,10 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/parser"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/parser"
 )
 
 type Child struct {

--- a/encode.go
+++ b/encode.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/printer"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/parser"
+	"github.com/nobl9/go-yaml/printer"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-yaml/parser"
+	"github.com/nobl9/go-yaml/parser"
 
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/ast"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/ast"
 )
 
 var zero = 0

--- a/error.go
+++ b/error.go
@@ -1,9 +1,9 @@
 package yaml
 
 import (
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/error_test.go
+++ b/error_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goccy/go-yaml
+module github.com/nobl9/go-yaml
 
 go 1.19
 

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/goccy/go-yaml/printer"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/printer"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -3,8 +3,8 @@ package lexer
 import (
 	"io"
 
-	"github.com/goccy/go-yaml/scanner"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/scanner"
+	"github.com/nobl9/go-yaml/token"
 )
 
 // Tokenize split to token instances from string

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/goccy/go-yaml/lexer"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/lexer"
+	"github.com/nobl9/go-yaml/token"
 )
 
 func TestTokenize(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/goccy/go-yaml/ast"
+	"github.com/nobl9/go-yaml/ast"
 )
 
 // DecodeOption functional option type for Decoder

--- a/parser/context.go
+++ b/parser/context.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 )
 
 // context context at parsing
@@ -179,7 +179,7 @@ func newContext(tokens token.Tokens, mode Mode) *context {
 				continue
 			}
 			// keep prev/next reference between tokens containing comments
-			// https://github.com/goccy/go-yaml/issues/254
+			// https://github.com/nobl9/go-yaml/issues/254
 			filteredTokens = append(filteredTokens, tk)
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/lexer"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/lexer"
+	"github.com/nobl9/go-yaml/token"
 	"golang.org/x/xerrors"
 )
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/lexer"
-	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/lexer"
+	"github.com/nobl9/go-yaml/parser"
+	"github.com/nobl9/go-yaml/token"
 )
 
 func TestParser(t *testing.T) {

--- a/path.go
+++ b/path.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/printer"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/parser"
+	"github.com/nobl9/go-yaml/printer"
 )
 
 // PathString create Path from string

--- a/path_test.go
+++ b/path_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/parser"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/parser"
 )
 
 func builder() *yaml.PathBuilder { return &yaml.PathBuilder{} }

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/token"
 )
 
 // Property additional property set for each the token

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/goccy/go-yaml/lexer"
-	"github.com/goccy/go-yaml/printer"
+	"github.com/nobl9/go-yaml/lexer"
+	"github.com/nobl9/go-yaml/printer"
 )
 
 func Test_Printer(t *testing.T) {

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -3,7 +3,7 @@ package scanner
 import (
 	"sync"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 )
 
 const whitespace = ' '

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 )
 
 // IndentState state for indent

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,7 +3,7 @@ package token_test
 import (
 	"testing"
 
-	"github.com/goccy/go-yaml/token"
+	"github.com/nobl9/go-yaml/token"
 )
 
 func TestToken(t *testing.T) {

--- a/validate_test.go
+++ b/validate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 )
 
 func TestStructValidator(t *testing.T) {

--- a/yaml.go
+++ b/yaml.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/internal/errors"
+	"github.com/nobl9/go-yaml/ast"
+	"github.com/nobl9/go-yaml/internal/errors"
 	"golang.org/x/xerrors"
 )
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/xerrors"
 
-	"github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/ast"
+	"github.com/nobl9/go-yaml"
+	"github.com/nobl9/go-yaml/ast"
 )
 
 func TestMarshal(t *testing.T) {


### PR DESCRIPTION
We can no longer proceed with the `replace` clause for the forked version as running `go install` on projects using this fork results in an error:

```
go install github.com/nobl9/sloctl/cmd/sloctl@latest
go: downloading github.com/nobl9/sloctl v0.3.2
go: github.com/nobl9/sloctl/cmd/sloctl@latest (in github.com/nobl9/sloctl@v0.3.2):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```